### PR TITLE
Adopt '[tool.pytest-enabler]' for configuration (PEP 518)

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,3 +1,9 @@
+Development Version
+===================
+
+#4: pytest-enabler now uses ``[tool.pytest-enabler]`` for configuration
+in accordance with :pep:`518#tool-table` (``[pytest.enabler]`` is deprecated).
+
 v1.2.1
 ======
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,5 +1,5 @@
-Development Version
-===================
+v1.3.0
+======
 
 #4: pytest-enabler now uses ``[tool.pytest-enabler]`` for configuration
 in accordance with :pep:`518#tool-table` (``[pytest.enabler]`` is deprecated).

--- a/README.rst
+++ b/README.rst
@@ -22,7 +22,7 @@
 
 The 'enabler' plugin allows configuration of plugins if present, but omits the settings if the plugin is not present. For example, to configure black to be enabled if the plugin is present, but not when it is not, add the following to your pyproject.toml::
 
-    [pytest.enabler.black]
+    [tool.pytest-enabler.black]
     addopts = "--black"
 
 Known to work with the following plugins:

--- a/pytest_enabler/__init__.py
+++ b/pytest_enabler/__init__.py
@@ -1,6 +1,7 @@
 import contextlib
 import shlex
 import sys
+import warnings
 
 import toml
 from jaraco.context import suppress
@@ -24,7 +25,12 @@ def none_as_empty(ob):
 def read_plugins(filename):
     with open(filename) as strm:
         defn = toml.load(strm)
-    return defn["pytest"]["enabler"]
+    if "pytest" in defn and "enabler" in defn["pytest"]:
+        msg = "pytest-enabler configuration should use the `[tool.pytest-enabler]` "
+        msg += "table in pyproject.toml (`[pytest.enabler]` is now deprecated)."
+        warnings.warn(msg, DeprecationWarning)
+        return defn["pytest"]["enabler"]
+    return defn["tool"]["pytest-enabler"]
 
 
 def pytest_load_initial_conftests(early_config, parser, args):

--- a/pytest_enabler/__init__.py
+++ b/pytest_enabler/__init__.py
@@ -25,12 +25,18 @@ def none_as_empty(ob):
 def read_plugins(filename):
     with open(filename) as strm:
         defn = toml.load(strm)
-    if "pytest" in defn and "enabler" in defn["pytest"]:
-        msg = "pytest-enabler configuration should use the `[tool.pytest-enabler]` "
-        msg += "table in pyproject.toml (`[pytest.enabler]` is now deprecated)."
-        warnings.warn(msg, DeprecationWarning)
-        return defn["pytest"]["enabler"]
-    return defn["tool"]["pytest-enabler"]
+    return _read_plugins_legacy(defn) or defn["tool"]["pytest-enabler"]
+
+
+@suppress(KeyError)
+def _read_plugins_legacy(defn):
+    value = defn["pytest"]["enabler"]
+    msg = (
+        "pytest-enabler configuration should use the `[tool.pytest-enabler]` "
+        "table in pyproject.toml (`[pytest.enabler]` is now deprecated)."
+    )
+    warnings.warn(msg, DeprecationWarning)
+    return value
 
 
 def pytest_load_initial_conftests(early_config, parser, args):


### PR DESCRIPTION
As described in #4, PEP 518 restricts the name of tables in `pyproject.toml` (currently, with PEP 517/518/621, only `[build-system]`, `[project]` and `[tool.*]` are allowed) and specifies that tools should use `[tool.<name on PyPI>]` for storing their configuration.

This PR fix #4, by deprecating `[pytest.enabler]` and migrating to `[tool.pytest-enabler]`.

The usage of hyphen (`-`) is preferred to underscore for the sake of consistency with PEP 517/518/621 (also the official name of the distribution, before normalisation, seems to be `pytest-enabler` according to `setup.cfg`).